### PR TITLE
Forward auth on known domain

### DIFF
--- a/earthdata_download/download.py
+++ b/earthdata_download/download.py
@@ -23,7 +23,7 @@ SCHEMES = ['https', 'http', 'ftp']
 
 class EarthdataSession(requests.Session):
 
-    AUTH_HOST = 'urs.earthdata.nasa.gov'
+    AUTH_DOMAINS = ['nasa.gov', 'usgs.gov']
 
     def __init__(self, username, password):
         """Create Earthdata Session that preserves headers when redirecting"""
@@ -31,16 +31,18 @@ class EarthdataSession(requests.Session):
         self.auth = (username, password)
 
     def rebuild_auth(self, prepared_request, response):
-        """Keep headers upon redirect as long as we are on self.AUTH_HOST"""
+        """Keep headers upon redirect as long as we are on any of self.AUTH_DOMAINS"""
         headers = prepared_request.headers
         url = prepared_request.url
         if 'Authorization' in headers:
             original_parsed = requests.utils.urlparse(response.request.url)
             redirect_parsed = requests.utils.urlparse(url)
+            original_domain = '.'.join(original_parsed.hostname.split('.')[-2:])
+            redirect_domain = '.'.join(redirect_parsed.hostname.split('.')[-2:])
             if (
-                    original_parsed.hostname != redirect_parsed.hostname and
-                    redirect_parsed.hostname != self.AUTH_HOST and
-                    original_parsed.hostname != self.AUTH_HOST):
+                    original_domain != redirect_domain and
+                    redirect_domain not in self.AUTH_DOMAINS and
+                    original_domain not in self.AUTH_DOMAINS):
                 del headers['Authorization']
 
 

--- a/tests/test_api_download.py
+++ b/tests/test_api_download.py
@@ -20,3 +20,19 @@ def test_download_single(api_query_kw, earthdata_credentials, tmpdir):
     assert os.path.isfile(local_filename)
     assert os.path.abspath(os.path.dirname(local_filename)) == os.path.abspath(tempdir)
     assert os.path.getsize(local_filename) > 1e6
+
+
+@pytest.mark.nasa
+def test_download_multiple(api_query_kw, earthdata_credentials, tmpdir):
+    api = EarthdataAPI(**earthdata_credentials)
+    data_urls = api.query(**api_query_kw)
+    tempdir = str(tmpdir)
+
+    twice = [data_urls[0]] * 2
+    local_files = api.download(twice, download_dir=tempdir, skip_existing=True)
+    assert isinstance(local_files, list)
+    assert local_files
+    assert len(local_files) == 2
+    assert local_files[0] == local_files[1]
+    local_filename = local_files[0]
+    assert os.path.isfile(local_filename)


### PR DESCRIPTION
Authorization is stripped when leaving `cmr.earthdata.nasa.gov`. But files to download might be hosted on various other servers, amongst others at `e4ftl01.cr.usgs.gov`. I guess we should forward authorization there, too.

Current solution: Forward as long as on `nasa.gov` or `usgs.gov`. Not perfect, but might work for now.